### PR TITLE
Add 0x prefix to pushArg

### DIFF
--- a/src/play.js
+++ b/src/play.js
@@ -112,7 +112,7 @@ function printCode(code) {
     if (pushSize) {
       const pushArg = code.slice(i + 2, i + 2 + 2 * pushSize);
       opcodeHexItem = { value: opcodeHex + pushArg, color: null };
-      opcodeItem = { value: `${opcode}${pushSize} ${pushArg}`, color: null };
+      opcodeItem = { value: `${opcode}${pushSize} 0x${pushArg}`, color: null };
       i += 2 + 2 * pushSize;
     } else {
       let color = null;


### PR DESCRIPTION
`pushArgs` must have the `0x` prefix, otherwise they will be incorrectly interpreted as decimal instead of hex.

For example, puzzle 9 is currently printed like this:

```
############
# Puzzle 9 #
############

00      36        CALLDATASIZE
01      6003      PUSH1 03
03      10        LT
04      6009      PUSH1 09
06      57        JUMPI
07      FD        REVERT
08      FD        REVERT
09      5B        JUMPDEST
0A      34        CALLVALUE
0B      36        CALLDATASIZE
0C      02        MUL
0D      6008      PUSH1 08
0F      14        EQ
10      6014      PUSH1 14
12      57        JUMPI
13      FD        REVERT
14      5B        JUMPDEST
15      00        STOP
```

The evm.codes playground will interpret `PUSH1 14` as the bytecode `600e` (`0e` is 14 in hex), and not `6014` as expected.

This PR will update `pushArgs` so it has the `0x` prefix. So puzzle 9 will look like this:

```
############
# Puzzle 9 #
############

00      36        CALLDATASIZE
01      6003      PUSH1 0x03
03      10        LT
04      6009      PUSH1 0x09
06      57        JUMPI
07      FD        REVERT
08      FD        REVERT
09      5B        JUMPDEST
0A      34        CALLVALUE
0B      36        CALLDATASIZE
0C      02        MUL
0D      6008      PUSH1 0x08
0F      14        EQ
10      6014      PUSH1 0x14
12      57        JUMPI
13      FD        REVERT
14      5B        JUMPDEST
15      00        STOP
```